### PR TITLE
Add a task that prints to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Inspired by:
 Add this to your sbt build plugins, in either `project/plugins.sbt` or `~/.sbt/1.0/plugins/build.sbt`:
 
 ```scala
-addSbtPlugin("lt.dvim.authors" % "sbt-authors" % "1.0.2")
+addSbtPlugin("lt.dvim.authors" % "sbt-authors" % "1.1")
 resolvers += Resolver.bintrayRepo("jypma", "maven") // for ts-reaktive
 ```
 
@@ -31,24 +31,25 @@ resolvers += Resolver.bintrayRepo("jypma", "maven") // for ts-reaktive
 
 ## Tasks
 
-* `authors <from> <to>` Fetches the authors summary between two tags and puts it to your clipboard.
+* `authors <from> <to>` Fetches the authors summary between two tags and prints it to stdout.
 * `authorsFile <from> <to>` Writes the same authors summary to a `target/authors.md` file.
+* `authorsClipboard <from> <to>` Puts the same authors summary to your clipboard.
 
 ## Example usage
 
 * `sbt "authors v0.20 v0.21"`
 
   Fetches the authors summary between `v0.20` and `v0.21` tags and puts it to your clipboard
-  
+
 * `sbt "authors v0.20 HEAD"`
 
   Fetches the authors summary between `v0.20` tag and the last commit and puts it to your clipboard
-  
-* `coursier launch -r bintray:jypma/maven lt.dvim.authors::authors-core:1.0.2 -- akka/alpakka v0.19 v0.20 ./`
 
-  This will use [`coursier`](https://github.com/coursier/coursier) to launch the tool directly. You will have to be in the checkedout project directory when running this command. It will print out the authors summary to stdout. 
-  
-* `coursier bootstrap -r bintray:jypma/maven lt.dvim.authors:authors-core_2.12:1.0.2 -o authors `
+* `coursier launch -r bintray:jypma/maven lt.dvim.authors::authors-core:1.1 -- akka/alpakka v0.19 v0.20 ./`
+
+  This will use [`coursier`](https://github.com/coursier/coursier) to launch the tool directly. You will have to be in the checkedout project directory when running this command. It will print out the authors summary to stdout.
+
+* `coursier bootstrap -r bintray:jypma/maven lt.dvim.authors:authors-core_2.12:1.1 -o authors `
 
   This will create an executable `authors` which then can be used to launch the application with the same arguments as mentioned above: `authors akka/alpakka v0.19 v0.20 ./`
 

--- a/plugin/src/main/scala/AuthorsKeys.scala
+++ b/plugin/src/main/scala/AuthorsKeys.scala
@@ -19,6 +19,7 @@ package lt.dvim.authors
 import sbt._
 
 trait AuthorsKeys {
-  val authors = inputKey[Unit]("Generate authors report to clipboard.")
+  val authors = inputKey[Unit]("Generate authors report to stdout.")
   val authorsFile = inputKey[File]("Generate authors report to a file.")
+  val authorsClipboard = inputKey[Unit]("Generate authors report to clipboard.")
 }

--- a/plugin/src/main/scala/AuthorsPlugin.scala
+++ b/plugin/src/main/scala/AuthorsPlugin.scala
@@ -41,13 +41,8 @@ object AuthorsPlugin extends AutoPlugin {
         baseDirectory.value,
         streams.value
       ).map { s =>
-        import java.awt.Toolkit
-        import java.awt.datatransfer._
-        val clipboard = Toolkit.getDefaultToolkit.getSystemClipboard
-        val selection = new StringSelection(s)
-        clipboard.setContents(selection, selection)
-
-        streams.value.log.info("Authors summary placed into the clipboard.")
+        println(s)
+        streams.value.log.info("Authors summary written to stdout.")
       }
 
       Await.result(summary, 30.seconds)
@@ -69,7 +64,27 @@ object AuthorsPlugin extends AutoPlugin {
 
       Await.result(summary, 30.seconds)
     },
-    authorsFile / aggregate := false
+    authorsFile / aggregate := false,
+    authorsClipboard := {
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val summary = authorsSummary(
+        ArgsParser.parsed,
+        scmInfo.value.orElse((ThisBuild / scmInfo).value),
+        baseDirectory.value,
+        streams.value
+      ).map { s =>
+        import java.awt.Toolkit
+        import java.awt.datatransfer._
+        val clipboard = Toolkit.getDefaultToolkit.getSystemClipboard
+        val selection = new StringSelection(s)
+        clipboard.setContents(selection, selection)
+
+        streams.value.log.info("Authors summary placed into the clipboard.")
+      }
+
+      Await.result(summary, 30.seconds)
+    },
+    authorsClipboard / aggregate := false
   )
 
   private def authorsSummary(

--- a/plugin/src/sbt-test/authors/summary/test
+++ b/plugin/src/sbt-test/authors/summary/test
@@ -6,9 +6,13 @@ $ exec git clone https://github.com/2m/authors.git target/authors
 > set ThisBuild / scmInfo := Some(ScmInfo(url("https://github.com/2m/authors"),"git@github.com:2m/authors.git"))
 > set scmInfo := None
 
-# this task copies output to the clipboard, so no real way to check the output
+# this task prints output to stdout, so no real way to check the output
 # therefore just run it to see if it succeeds
 > authors v1.0.0 v1.0.1
+
+# this task copies output to the clipboard, so no real way to check the output
+# therefore just run it to see if it succeeds
+> authorsClipboard v1.0.0 v1.0.1
 
 > authorsFile v1.0.0 v1.0.1
 $ must-mirror target/authors/target/authors.md expected-authors.md


### PR DESCRIPTION
The default `authors` sbt task now prints to stdout. A new `authorsClipboard` command puts the summary to the clipboard.

Implements the suggestion from #81